### PR TITLE
Capture constness on elaborated types

### DIFF
--- a/src/type.c
+++ b/src/type.c
@@ -603,9 +603,22 @@ resect_type_category get_type_category(resect_type_kind kind) {
  */
 resect_type resect_type_create(resect_visit_context visit_context, resect_translation_context context,
                                CXType clang_type) {
+    resect_type type = resect_find_type(context, clang_type);
+    if (type != NULL) {
+        return type;
+    }
+
+    CXType original_clang_type = clang_type;
+    resect_bool is_const = false;
+    // Not sure this can be true more than once -- but just in case, we loop
+    while (clang_type.kind == CXType_Elaborated) {
+	if (clang_isConstQualifiedType(clang_type)) {
+	    is_const = true;
+	}
+	// Can unwrap to an Unexposed
+	clang_type = clang_Type_getNamedType(clang_type);
+    }
     switch (clang_type.kind) {
-        case CXType_Elaborated:
-            return resect_type_create(visit_context, context, clang_Type_getNamedType(clang_type));
         case CXType_Unexposed: {
             CXType canonical_type = clang_getCanonicalType(clang_type);
             if (CXType_Unexposed != canonical_type.kind) {
@@ -617,11 +630,6 @@ resect_type resect_type_create(resect_visit_context visit_context, resect_transl
             // skip attributes
             return resect_type_create(visit_context, context, clang_Type_getModifiedType(clang_type));
         default: ;
-    }
-
-    resect_type type = resect_find_type(context, clang_type);
-    if (type != NULL) {
-        return type;
     }
 
     type = malloc(sizeof(struct P_resect_type));
@@ -650,7 +658,7 @@ resect_type resect_type_create(resect_visit_context visit_context, resect_transl
     type->data_deallocator = NULL;
     type->data = NULL;
 
-    resect_register_type(context, clang_type, type);
+    resect_register_type(context, original_clang_type, type);
 
     CXCursor declaration_cursor = clang_getTypeDeclaration(clang_type);
     if (declaration_cursor.kind == CXCursor_NoDeclFound) {
@@ -699,6 +707,9 @@ resect_type resect_type_create(resect_visit_context visit_context, resect_transl
     }
 
     type->initialized = true;
+    if (is_const) {
+        type->const_qualified = true;
+    }
 
     if (type->decl != NULL) {
         if (resect_context_diagnostics_level(context) >= RESECT_DIAGNOSTICS_WARNING

--- a/src/type.c
+++ b/src/type.c
@@ -612,11 +612,11 @@ resect_type resect_type_create(resect_visit_context visit_context, resect_transl
     resect_bool is_const = false;
     // Not sure this can be true more than once -- but just in case, we loop
     while (clang_type.kind == CXType_Elaborated) {
-	if (clang_isConstQualifiedType(clang_type)) {
-	    is_const = true;
-	}
-	// Can unwrap to an Unexposed
-	clang_type = clang_Type_getNamedType(clang_type);
+        if (clang_isConstQualifiedType(clang_type)) {
+            is_const = true;
+        }
+        // Can unwrap to an Unexposed
+        clang_type = clang_Type_getNamedType(clang_type);
     }
     switch (clang_type.kind) {
         case CXType_Unexposed: {


### PR DESCRIPTION
I started trying to compile the generated adapter, and the first problem I ran into was that Claw was generating getter/setter functions for global variables declared const.

For example, source essentially like this (greatly simplified):

```
struct Symbol {
    explicit constexpr Symbol(int uniq) : value(uniq) {}
    constexpr operator int() const noexcept { return value; }
private:
    int value;
};

constexpr Symbol view_copy(42);
```
produced this output:
```
__CLAW_API void __claw_set_c10WprimWview_copy(struct c10::Symbol* __claw_value_) {
// /home/gyro/Repos/Claw-Torch/libtorch/include/ATen/core/interned_strings.h:353:1

c10::prim::view_copy = *__claw_value_;
}

__CLAW_API struct c10::Symbol* __claw_get_c10WprimWview_copy() {
// /home/gyro/Repos/Claw-Torch/libtorch/include/ATen/core/interned_strings.h:353:1

return (struct c10::Symbol*)&c10::prim::view_copy;
}
```

I traced the problem to these lines near the beginning of `resect_type_create`:

```
        case CXType_Elaborated:
            return resect_type_create(visit_context, context, clang_Type_getNamedType(clang_type));
```

I wondered whether the constness was set on the elaborated type, and was therefore being lost, and this proved to be the case.  Working out a fix took some time and experimentation, but I finally came up with something I'm happy with.

(I suspect this fixes the bug that you wrote `claw.resect::ensure-const-type-if-needed` to work around, but I haven't checked.)

The idea is that we need to use the elaborated type as the registration key so that we can safely mark the type const once it is built.  This requires moving the `resect_find_type` call to the top, and replacing the recursive call with (a) noting whether the elaborated type was const, and (b) unwrapping it for the benefit of subsequent processing.
